### PR TITLE
fix: correct macro definition for symstub_solve to use RESOLVE_STUBS

### DIFF
--- a/include/tinyhook.h
+++ b/include/tinyhook.h
@@ -56,7 +56,7 @@ TH_VIS void *symbol_resolve(uint32_t image_index, const char *symbol_name, uint 
 
 #define symtbl_solve(image_index, symbol_name)  symbol_resolve(image_index, symbol_name, RESOLVE_SYMTAB)
 #define symexp_solve(image_index, symbol_name)  symbol_resolve(image_index, symbol_name, RESOLVE_EXPORT)
-#define symstub_solve(image_index, symbol_name) symbol_resolve(image_index, symbol_name, RESOLVE_STUB)
+#define symstub_solve(image_index, symbol_name) symbol_resolve(image_index, symbol_name, RESOLVE_STUBS)
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This pull request makes a minor update to the symbol resolution macros in `tinyhook.h`. The macro for resolving stub symbols now uses `RESOLVE_STUBS` instead of `RESOLVE_STUB` to match the correct constant.

* Updated the `symstub_solve` macro in `tinyhook.h` to use `RESOLVE_STUBS` as the third argument, ensuring correct symbol resolution for stubs.